### PR TITLE
Add Support for Custom Checker

### DIFF
--- a/cprep/files.py
+++ b/cprep/files.py
@@ -4,7 +4,7 @@ import glob
 import os 
 
 
-KINDS = ['generator', 'validator', 'solution', 'tests']
+KINDS = ['generator', 'validator', 'solution', 'tests', 'checker']
 
 
 def _discover(patterns, base_dir="", **kwargs):

--- a/cprep_cli/config.yaml
+++ b/cprep_cli/config.yaml
@@ -42,6 +42,9 @@ discovery:
   - pattern: "sol*.cpp"
     kind: solution
 
+  - pattern: "check*.cpp"
+    kind: checker
+
   - pattern: "{problem}-gen*.cpp"
     kind: generator
   - pattern: "{problem}_gen*.cpp"


### PR DESCRIPTION
Not sure why this was not supported, as 99% of the code is already present.

What this does:
 * Adds the checker kind, to have the checker file be discovered and compiled.
 * Changes the evaluation function:
     * If no checker file was present, does not change behavior.
     * If a checker file was present, then it writes the input, output and answer to a tempfile and calls the checker.